### PR TITLE
added Repl clear & reShape with size

### DIFF
--- a/EditorExample/src/ofApp.cpp
+++ b/EditorExample/src/ofApp.cpp
@@ -117,7 +117,8 @@ void ofApp::mouseReleased(int x, int y, int button){}
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	editor.reShape();
+	editor.reShape(); // set new size using window or screen size
+	//editor.reShape(w, h); // set new size manually
 }
 
 //--------------------------------------------------------------

--- a/src/Repl.cpp
+++ b/src/Repl.cpp
@@ -169,6 +169,10 @@ void Repl::clear() {
 	printPrompt();
 }
 
+void Repl::clearHistory() {
+	historyClear();
+}
+
 // PRIVATE
 
 //--------------------------------------------------------------

--- a/src/Repl.h
+++ b/src/Repl.h
@@ -46,6 +46,9 @@ public:
 	/// clear the console
 	void clear();
 	
+	/// clear the command history
+	void clearHistory();
+	
 	/// text to be evaluated, needed for ofEvent
 	string evalText;
 

--- a/src/ofxGLEditor.cpp
+++ b/src/ofxGLEditor.cpp
@@ -251,7 +251,14 @@ void ofxGLEditor::keyPressed(int key){
 				glEditors[currentEditor]->BlowupCursor();
 				break;
 			case 't': case 20: bHideEditor = !bHideEditor; break;
-			case 'a': case 1: clearText(); break;
+			case 'a': case 1:
+				if(currentEditor == 0) {
+					clearRepl();
+				}
+				else {
+					clearText();
+				}
+				break;
 			case 'c': case 3: copyToClipBoard(); break;
 			case 'v': case 22: pasteFromClipBoard(); break;
 			case 's': case 19: {
@@ -378,10 +385,15 @@ void ofxGLEditor::keyReleased(int key){
 void ofxGLEditor::reShape(){
 	int w = (ofGetWindowMode() == OF_WINDOW)?ofGetViewportWidth():ofGetScreenWidth();
 	int h = (ofGetWindowMode() == OF_WINDOW)?ofGetViewportHeight():ofGetScreenHeight();
+	reShape(w, h);
+}
+
+//--------------------------------------------------------------
+void ofxGLEditor::reShape(int width, int height) {
 	for(int i = 0; i < (int) glEditors.size(); i++){
-		if(glEditors[i]) glEditors[i]->Reshape(w, h);
+		if(glEditors[i]) glEditors[i]->Reshape(width, height);
 	}
-	glFileDialog->Reshape(w, h);
+	glFileDialog->Reshape(width, height);
 }
 
 //--------------------------------------------------------------
@@ -488,18 +500,14 @@ void ofxGLEditor::clearText(int editor){
 		ofLogError("ofxGLEditor") << "cannot clear text in unknown editor " << editor;
 		return;
 	}
+	else if(editor == 0){
+		editor = currentEditor;
+	}
 	
+	 // reset filename
 	ofLogVerbose("ofxGLEditor") << "cleared text in editor" << currentEditor;
 	glEditors[editor]->ClearAllText();
-	if(editor == 0) {
-		if(glEditors[0]) {
-			Repl *repl = (Repl*) glEditors[0];
-			repl->clear();
-		}
-	}
-	else { // reset filename
-		saveFiles[editor] = "";
-	}
+	saveFiles[editor] = "";
 }
 
 //--------------------------------------------------------------
@@ -630,6 +638,23 @@ void ofxGLEditor::evalReplReturn(const string &text) {
 	if(glEditors[0]) {
 		Repl *repl = (Repl*) glEditors[0];
 		repl->printEvalReturn(string_to_wstring(text));
+	}
+}
+
+//--------------------------------------------------------------
+void ofxGLEditor::clearRepl() {
+	if(glEditors[0]) {
+		Repl *repl = (Repl*) glEditors[0];
+		repl->clear();
+		ofLogVerbose("ofxGLEditor") << "cleared repl";
+	}
+}
+
+void ofxGLEditor::clearReplHistory() {
+	if(glEditors[0]) {
+		Repl *repl = (Repl*) glEditors[0];
+		repl->clearHistory();
+		ofLogVerbose("ofxGLEditor") << "cleared repl history";
 	}
 }
 
@@ -826,4 +851,3 @@ void ofxGLEditor::Editor::CountLines(){
 			m_LineCount++;
 	}
 }
-	

--- a/src/ofxGLEditor.h
+++ b/src/ofxGLEditor.h
@@ -97,7 +97,8 @@ public:
 	/// reshape the drawing area
 	/// call this if you change the window size (fullscreen, etc)
 	void reShape();
-	
+	void reShape(int width, int height); //< set your own size
+
 /// \section Editor
 	
 	/// paste the latest text from the system clipboard
@@ -137,7 +138,7 @@ public:
 	/// clear the contents of *all* editors
 	void clearAllText();
 	
-	/// set the current editor by index, from 1 - 9
+	/// set the current editor by index, from 1 - 9 (0 is Repl)
 	void setCurrentEditor(int editor);
 	
 	/// get the index of the current editor, from 1 - 9 (0 is REPL)
@@ -170,6 +171,7 @@ public:
 	unsigned int getCurrentPos(int editor = 0);
 	
 /// \section Repl (Read-Eval-Print Loop)
+/// switch to the Repl via setCurrentEditor(0)
 	
 	/// send a response to the last evalReplEvent to the Repl console
 	///
@@ -178,6 +180,12 @@ public:
 	///
 	/// note: this does nothing if the repl was not enabled in setup()
 	void evalReplReturn(const string &text="");
+	
+	/// clears text in Repl buffer, does not clear history
+	void clearRepl();
+	
+	/// clears Repl history, does not clear buffer text
+	void clearReplHistory();
 	
 	/// set/get the Repl greeting banner, default: ""
 	static void setReplBanner(const string &text); //< call this before setup()
@@ -270,8 +278,8 @@ private:
 	ClipBoard clipBoard;
     
 	unsigned int numEditors;
-	int currentEditor; ///< note: 0-9
-	vector<string> saveFiles; ///< one for each editor
+	int currentEditor; //< note: 0-9
+	vector<string> saveFiles; //< one for each editor
     
 	bool bAltPressed;
 	bool bShiftPressed;


### PR DESCRIPTION
a couple more small additions I needed:
- Repl text is now cleared correctly, you can also do this with clearRepl() & clearReplHistory() functions
- added reShape with explicit size, might be useful in certain situaitons
