### PR TITLE
Fix invalid read when applying color scheme

### DIFF
--- a/src/ofxEditor.cpp
+++ b/src/ofxEditor.cpp
@@ -332,7 +332,7 @@ void ofxEditor::draw() {
 					continue;
 				}
 				
-				ofColor *textColor;
+				ofColor *textColor = NULL;
 				switch(tb.type) {
 				
 					case UNKNOWN:
@@ -366,7 +366,10 @@ void ofxEditor::draw() {
 					default:
 						break;
 				}
-				s_font->setColor(*textColor, m_settings->getAlpha());
+
+				if (textColor) {
+					s_font->setColor(*textColor, m_settings->getAlpha());
+				}
 				
 				// draw block chars
 				for(int i = 0; i < tb.text.length(); ++i) {


### PR DESCRIPTION
This fixes a possible segfault caused by an invalid read. Sometimes `textColor` was still a NULL value.