### PR TITLE
Define functions for "flashing" a selection

### DIFF
--- a/src/ofxEditor.cpp
+++ b/src/ofxEditor.cpp
@@ -39,6 +39,9 @@
 // max time in secs for cursor to "blow up"
 #define BLOWUP_FLASHES 1.8
 
+// max time in secs for selection to "flash"
+#define SELECTION_FLASH_DURATION 1
+
 // max cursor blow up size in chars
 #define CURSOR_MAX_WIDTH 40
 #define CURSOR_MAX_HEIGHT 40
@@ -104,6 +107,8 @@ ofxEditor::ofxEditor() {
 	m_flash = 0;
 	m_blowupCursor = false;
 	m_blowup = 0;
+	m_flashSelection = false;
+	m_flashSelTime = 0;
 	
 	m_autoFocus = false;
 	m_posX = m_posY = 0;
@@ -147,6 +152,8 @@ ofxEditor::ofxEditor(ofxEditorSettings &sharedSettings) {
 	m_flash = 0;
 	m_blowupCursor = false;
 	m_blowup = 0;
+	m_flashSelection = false;
+	m_flashSelTime = 0;
 	
 	m_autoFocus = false;
 	m_posX = m_posY = 0;
@@ -263,6 +270,15 @@ void ofxEditor::draw() {
 			m_posX = -(currentLineWidth-m_visibleWidth);
 		}
 		m_desiredXPos = offsetToCurrentLineStart();
+	}
+
+	// update flash animation counter
+	if (m_flashSelection) {
+		// set this to zero when starting
+		m_flashSelTime += m_delta;
+		if (m_flashSelTime >= SELECTION_FLASH_DURATION) {
+			m_flashSelection = false;
+		}
 	}
 
 	ofPushStyle();
@@ -397,6 +413,11 @@ void ofxEditor::draw() {
 					if(m_selection != NONE && textPos >= m_highlightStart && textPos < m_highlightEnd) {
 						drawSelectionCharBlock(tb.text[i], x, y);
 					}
+
+					// draw flash
+					if (m_flashSelection && textPos >= m_flashStart && textPos < m_flashEnd) {
+						drawFlashCharBlock(tb.text[i], x, y);
+					}
 					
 					// draw cursor
 					if(textPos == m_position) {
@@ -463,6 +484,11 @@ void ofxEditor::draw() {
 				// draw selection
 				if(m_selection != NONE && i >= m_highlightStart && i < m_highlightEnd) {
 					drawSelectionCharBlock(m_text[i], x, y);
+				}
+
+				// draw flash
+				if (m_flashSelection && i >= m_flashStart && i < m_flashEnd) {
+					drawFlashCharBlock(m_text[i], x, y);
 				}
 				
 				// draw cursor
@@ -1178,6 +1204,14 @@ void ofxEditor::blowupCursor() {
 }
 
 //--------------------------------------------------------------
+void ofxEditor::flashSelection(unsigned int start, unsigned int end) {
+	m_flashSelection = true;
+	m_flashSelTime = 0;
+	m_flashStart = start;
+	m_flashEnd = end;
+}
+
+//--------------------------------------------------------------
 bool ofxEditor::isSelection() {
 	return m_selection != NONE;
 }
@@ -1252,6 +1286,8 @@ void ofxEditor::setCurrentLinePos(unsigned int line, unsigned int character) {
 void ofxEditor::reset() {
 	m_blowupCursor = false;
 	m_blowup = 0.0f;
+	m_flashSelection = false;
+	m_flashSelTime = 0.0f;
 	m_position = 0;
 	setCurrentLine(0);
 	m_shiftState = false;
@@ -1354,6 +1390,15 @@ void ofxEditor::drawSelectionCharBlock(int c, int x, int y) {
 	ofSetColor(
 		m_settings->getSelectionColor().r, m_settings->getSelectionColor().g,
 		m_settings->getSelectionColor().b, m_settings->getSelectionColor().a * m_settings->getAlpha());
+	ofRect(x, y-s_charHeight, characterWidth(c), s_charHeight);
+}
+
+//--------------------------------------------------------------
+void ofxEditor::drawFlashCharBlock(int c, int x, int y) {
+	float cur_alpha = (SELECTION_FLASH_DURATION - m_flashSelTime) / SELECTION_FLASH_DURATION;
+
+	ofColor &color = m_settings->getFlashColor();
+	ofSetColor(color.r, color.g, color.b, cur_alpha * color.a * m_settings->getAlpha());
 	ofRect(x, y-s_charHeight, characterWidth(c), s_charHeight);
 }
 

--- a/src/ofxEditor.h
+++ b/src/ofxEditor.h
@@ -190,6 +190,9 @@ class ofxEditor {
 	
 		/// animate the cursor so it's easy to find
 		void blowupCursor();
+
+		/// flash text selection from start position to end position
+		void flashSelection(unsigned int start, unsigned int end);
 	
 		/// returns true if text is currently selected
 		bool isSelection();
@@ -316,6 +319,11 @@ class ofxEditor {
 		float m_flash;        //< cursor flash animation time
 		bool m_blowupCursor;  //< blow up the cursor?
 		float m_blowup;       //< how much the cursor is being blown up
+
+		bool m_flashSelection;      //< is selection flash on?
+		float m_flashSelTime;       //< flash animation time
+		unsigned int m_flashStart;  //< flash start pos
+		unsigned int m_flashEnd;    //< flash end pos
 	
 		// auto focus
 		bool m_autoFocus;       //< enable auto focus scaling?
@@ -375,6 +383,9 @@ class ofxEditor {
 	
 		/// draw a selection char block rectangle at pos
 		void drawSelectionCharBlock(int c, int x, int y);
+
+		/// flash over char block rectangle at pos
+		void drawFlashCharBlock(int c, int x, int y);
 	
 		/// draw the cursor at pos
 		void drawCursor(int x, int y);

--- a/src/ofxEditorSettings.cpp
+++ b/src/ofxEditorSettings.cpp
@@ -33,6 +33,7 @@ ofxEditorSettings::ofxEditorSettings() {
 	textShadowColor = ofColor(0);
 	cursorColor = ofColor(255, 255, 0, 200);
 	selectionColor = ofColor(0, 255, 0, 127);
+	flashColor = ofColor(0, 255, 0, 127);
 	matchingCharsColor = ofColor(0, 127, 255, 127);
 	lineNumberColor = ofColor(127);
 
@@ -109,6 +110,16 @@ void ofxEditorSettings::setSelectionColor(ofColor color) {
 //--------------------------------------------------------------
 ofColor& ofxEditorSettings::getSelectionColor() {
 	return selectionColor;
+}
+
+//--------------------------------------------------------------
+void ofxEditorSettings::setFlashColor(ofColor color) {
+	flashColor = color;
+}
+
+//--------------------------------------------------------------
+ofColor& ofxEditorSettings::getFlashColor() {
+	return flashColor;
 }
 
 //--------------------------------------------------------------

--- a/src/ofxEditorSettings.h
+++ b/src/ofxEditorSettings.h
@@ -58,6 +58,10 @@ class ofxEditorSettings {
 		/// selection color, default: green w/ alpha
 		void setSelectionColor(ofColor color);
 		ofColor& getSelectionColor();
+
+		/// flash color, default: green w/ alpha
+		void setFlashColor(ofColor color);
+		ofColor& getFlashColor();
 	
 		/// matching chars highlight color, default: blue w/ alpha
 		void setMatchingCharsColor(ofColor color);
@@ -91,6 +95,7 @@ class ofxEditorSettings {
 		ofColor textShadowColor;	//< text offset shadow color
 		ofColor cursorColor;	    //< text pos cursor color
 		ofColor selectionColor;     //< char selection highlight color
+		ofColor flashColor;         //< flash selection highlight color
 		ofColor matchingCharsColor; //< matching chars highlight color
 		ofColor lineNumberColor;    //< line number color
 


### PR DESCRIPTION
Related to #18 

This is useful for livecoding with languages that allow evaluation of string selections instead of the whole script file.

Functions defined:
- `ofxEditor::flashSelection(unsigned int start, unsigned int end)`
- `ofxEditorSettings::setFlashColor(ofColor)`
- `ofxEditorSettings::getFlashColor()`

By default, animation lasts 1 sec and flashing color is green (same as the default selection color).